### PR TITLE
Correcting error POST/DELETE with auth:api middleware to API routes

### DIFF
--- a/passport-client/public/js/app.js
+++ b/passport-client/public/js/app.js
@@ -827,10 +827,12 @@ var app = new Vue({
                     'Authorization': AuthStr
                 }
             };
-            axios.get(api_url + '/api/v1/projects', { 'headers': { 'Authorization': AuthStr } }).then(function (response) {
-                this.projects = response.data;
-            }.bind(this));
-            this.cancel();
+            if (AuthStr != 'Bearer ') {
+                axios.get(api_url + '/api/v1/projects', { 'headers': { 'Authorization': AuthStr } }).then(function (response) {
+                    this.projects = response.data;
+                }.bind(this));
+                this.cancel();
+            }
         },
         remove: function remove(project) {
             var AuthStr = 'Bearer ' + api_token;
@@ -848,18 +850,20 @@ var app = new Vue({
             var parameters = {
                 'headers': {
                     'Authorization': AuthStr
-                },
+                }
+            };
+            var value = {
                 'title': this.newTitle,
                 'description': this.newDescription
             };
             if (!this.editId) {
-                axios.post(api_url + '/api/v1/projects', parameters).then(function (response) {
+                axios.post(api_url + '/api/v1/projects', value, parameters).then(function (response) {
                     this.loadProjects();
                     this.newTitle = '';
                     this.newDescription = '';
                 }.bind(this));
             } else {
-                axios.put(api_url + '/api/v1/projects/' + this.editId, parameters).then(function (response) {
+                axios.put(api_url + '/api/v1/projects/' + this.editId, value, parameters).then(function (response) {
                     this.loadProjects();
                     this.newTitle = '';
                     this.newDescription = '';


### PR DESCRIPTION
Hi, with "auth:api" in middleware API routes, create and delete don't work with passport-client.